### PR TITLE
Support MediaFiles (and more)

### DIFF
--- a/onepy/onepy.py
+++ b/onepy/onepy.py
@@ -235,6 +235,8 @@ class PageContent():
                     self.files.append(Image(node))
                 elif (node.tag == namespace + "InsertedFile"):
                     self.files.append(InsertedFile(node))       
+                elif (node.tag == namespace + "MediaFile"):
+                    self.files.append(MediaFile(node, self))  
                 elif (node.tag == namespace + "Title"):
                     self._children.append(Title(node))       
 
@@ -386,6 +388,9 @@ class OE():
             elif (node.tag == namespace + "InsertedFile"):
                 self.files.append(InsertedFile(node, self))
 
+            elif (node.tag == namespace + "MediaFile"):
+                self.files.append(MediaFile(node, self))
+
 
 class InsertedFile():
 
@@ -419,7 +424,13 @@ class InsertedFile():
         self.last_modified_by = xml.get("lastModifiedBy")
         self.id = xml.get("objectID")   
 
+        
+# Dummy class to give the ability to type check files that 
+# derived from the MediaFile XML tag
+class MediaFile(InsertedFile):
+    pass
 
+    
 class Ink():
 
     # need to add position data to this class

--- a/onepy/onepy.py
+++ b/onepy/onepy.py
@@ -12,8 +12,8 @@ class OneNote():
         self.object_tree = cElementTree.fromstring(self.process.get_hierarchy("",4))
         self.hierarchy = Hierarchy(self.object_tree)
         
-    def get_page_content(self, page_id):
-        page_content_xml = cElementTree.fromstring(self.process.get_page_content(page_id))
+    def get_page_content(self, page_id, page_info=0):
+        page_content_xml = cElementTree.fromstring(self.process.get_page_content(page_id, page_info))
         return PageContent(page_content_xml)
         
 


### PR DESCRIPTION
I've added support for `MediaFiles` (audio/video recorded through OneNote) and also for passing through the `page_info` parameter from `onepy.OneNote.get_page_content()` to `onmanager.ONProcess.get_page_content()`
